### PR TITLE
Add installer sub-directory to OCP 4.0 instructions

### DIFF
--- a/learn/next_gen_installer.md
+++ b/learn/next_gen_installer.md
@@ -47,7 +47,7 @@ $ ansible-playbook -i "<jump_node_public_dns>," playbooks/install_fedora_ocp4.ya
 Launch a cluster:
 
 ```bash
-$ cd go/src/github.com/openshift/
+$ cd go/src/github.com/openshift/installer/
 ### download terraform into bin folder
 $ ./hack/get-terraform.sh
 ### build openshift-install binary in bin folder


### PR DESCRIPTION
Small update to add installer sub-dir to the doc.